### PR TITLE
Fix relayFee tokenIds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,17 +189,14 @@ export class MayanRoute<N extends Network>
       const relayFee =
         quote.fromChain !== "solana"
           ? {
-              token: Wormhole.tokenId(
-                fromChain.chain,
-                this.sourceTokenAddress(request)
-              ),
+              token: request.source.id,
               amount: amount.parse(
                 amount.denoise(quote.swapRelayerFee, quote.fromToken.decimals),
                 quote.fromToken.decimals
               ),
             }
           : {
-              token: Wormhole.tokenId(toChain.chain, this.destTokenAddress(request)),
+              token: request.destination.id,
               amount: amount.parse(
                 amount.denoise(quote.redeemRelayerFee, quote.toToken.decimals),
                 quote.toToken.decimals


### PR DESCRIPTION
Calling `this.destTokenAddress`/`this.sourceTokenAddress` on these is incorrect; these functions are for converting `address: 'native'` to the Mayan API's expected value `0x0000000000000000000000000000000000000000`. But we're not sending this value into the Mayan API; we're returning it to the Wormhole SDK consumer.