### PR TITLE
Don't parse USD value as token value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ class MayanRouteBase<N extends Network>
         // We parse this and return a standardized Wormhole SDK MinAmountError
 
         const amountMatch = e.message.match(/([\d\.]+)/);
-        if (amountMatch[1] !== undefined) {
+        if (amountMatch[1] !== undefined && !e.message.includes('$')) {
           const minAmountFloat = parseFloat(amountMatch[1]);
           const minAmount = amount.parse(minAmountFloat, request.source.decimals);
           return {


### PR DESCRIPTION
This will avoid returning an incorrect `MinAmountError` claiming the minimum amount is "100 ETH" when we get a response like this:

```
{"code":"AMOUNT_TOO_SMALL","msg":"Amount too small (min ~100$)"}
```