### PR TITLE
Support only USDC for source/dest tokens in Shuttle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import {
   NATIVE_CONTRACT_ADDRESS,
   fetchTokensForChain,
   getTransactionStatus,
+  getUSDCTokenId,
   supportedChains,
   toMayanChainName,
   txStatusToReceipt,
@@ -577,8 +578,32 @@ export class MayanRouteSHUTTLE<N extends Network>
 
   static meta = {
     name: "MayanSwapSHUTTLE",
-    provider: "Mayan Shuttle",
+    provider: "Mayan Shuttle Beta",
   };
 
   override protocols: MayanProtocol[] = ['SHUTTLE'];
+
+  static override supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]> {
+    if (!supportedChains().includes(fromChain.chain)) {
+      return Promise.resolve([]);
+    }
+
+    const usdcTokenId = getUSDCTokenId(fromChain.chain, fromChain.network);
+
+    return Promise.resolve(usdcTokenId ? [usdcTokenId] : []);
+  }
+
+  static override supportedDestinationTokens<N extends Network>(
+    _token: TokenId,
+    fromChain: ChainContext<N>,
+    toChain: ChainContext<N>
+  ): Promise<TokenId[]> {
+    if (!supportedChains().includes(fromChain.chain) || !supportedChains().includes(toChain.chain)) {
+      return Promise.resolve([]);
+    }
+
+    const usdcTokenId = getUSDCTokenId(toChain.chain, toChain.network);
+    
+    return Promise.resolve(usdcTokenId ? [usdcTokenId] : []);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -583,27 +583,27 @@ export class MayanRouteSHUTTLE<N extends Network>
 
   override protocols: MayanProtocol[] = ['SHUTTLE'];
 
-  static override supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]> {
+  static override async supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]> {
     if (!supportedChains().includes(fromChain.chain)) {
-      return Promise.resolve([]);
+      return [];
     }
 
     const usdcTokenId = getUSDCTokenId(fromChain.chain, fromChain.network);
 
-    return Promise.resolve(usdcTokenId ? [usdcTokenId] : []);
+    return usdcTokenId ? [usdcTokenId] : [];
   }
 
-  static override supportedDestinationTokens<N extends Network>(
+  static override async supportedDestinationTokens<N extends Network>(
     _token: TokenId,
     fromChain: ChainContext<N>,
     toChain: ChainContext<N>
   ): Promise<TokenId[]> {
     if (!supportedChains().includes(fromChain.chain) || !supportedChains().includes(toChain.chain)) {
-      return Promise.resolve([]);
+      return [];
     }
 
     const usdcTokenId = getUSDCTokenId(toChain.chain, toChain.network);
     
-    return Promise.resolve(usdcTokenId ? [usdcTokenId] : []);
+    return usdcTokenId ? [usdcTokenId] : [];
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,9 @@ import {
   routes,
   toChain,
   toNative,
+  circle,
+  Network,
+  Wormhole,
 } from "@wormhole-foundation/sdk-connect";
 import { isEvmNativeSigner } from "@wormhole-foundation/sdk-evm";
 import { SolanaUnsignedTransaction } from "@wormhole-foundation/sdk-solana";
@@ -439,3 +442,15 @@ export async function getTransactionStatus(
   }
   return null;
 }
+
+export function getUSDCTokenId(chain: Chain, network: Network): TokenId | undefined {
+  const usdcContract = circle.usdcContract.get(network, chain);
+  if (!usdcContract) {
+    return undefined;
+  }
+
+  return Wormhole.tokenId(
+    chain,
+    usdcContract,
+  );
+} 


### PR DESCRIPTION
Shuttle will support only USDC for any source/dest chains.