### PR TITLE
Parse txStatus.refundChain as an integer, not a chain name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mayanfinance/wormhole-sdk-route",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mayanfinance/wormhole-sdk-route",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mayanfinance/swap-sdk": "10.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mayanfinance/wormhole-sdk-route",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -311,8 +311,8 @@ export interface Tx {
 }
 
 export function txStatusToReceipt(txStatus: TransactionStatus): routes.Receipt {
-  const srcChain = toWormholeChainName(txStatus.sourceChain as MayanChainName);
-  const dstChain = toWormholeChainName(txStatus.destChain as MayanChainName);
+  const srcChain = toWormholeChainName(txStatus.sourceChain);
+  const dstChain = toWormholeChainName(txStatus.destChain);
 
   const originTxs = txStatus.txs
     .filter((tx) => {
@@ -344,7 +344,7 @@ export function txStatusToReceipt(txStatus: TransactionStatus): routes.Receipt {
   let refundTxs = [];
   if (txStatus.refundTxHash) {
     refundTxs.push({
-      chain: fromMayanChainName(txStatus.refundChain as MayanChainName),
+      chain: toWormholeChainName(txStatus.refundChain),
       txid: txStatus.refundTxHash
     });
   }


### PR DESCRIPTION
Fixes issue where track() throws when a refund happens and we try to parse the refundChain as a chain name when it's a chain id.